### PR TITLE
misc(package.json, request): Bumps 'request' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "lodash.find": "^4.3.0",
     "lodash.foreach": "^4.2.0",
     "lodash.reduce": "^4.3.0",
-    "request": "^2.72.0",
+    "request": "^2.87.0",
     "verror": "^1.6.1"
   }
 }


### PR DESCRIPTION
Hello! Just noticed this `nsp` warning this morning... although it lists `honeybadger` as the offending package it looks like that should be taken care of _there_ once a new version is cut (`1.12.2`?). 

This seems like a safe change to keep _this_ `package.json` up-to-date.

```
┌────────────┬────────────────────────────────────────────────────────────────────┐
│            │ Regular Expression Denial of Service                               │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Name       │ sshpk                                                              │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ CVSS       │ 8 (High)                                                           │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Installed  │ 1.13.1                                                             │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Vulnerable │ <1.14.1                                                            │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Patched    │ >=1.14.1                                                           │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Path       │ [package] > honeybadger@1.2.1 > request@2.79.0 >            │
│            │ http-signature@1.1.1 > sshpk@1.13.1                                │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ More Info  │ https://nodesecurity.io/advisories/606                             │
└────────────┴────────────────────────────────────────────────────────────────────┘
``` 

