### PR TITLE
Add Webpack 4 Support

### DIFF
--- a/src/HoneybadgerSourceMapPlugin.js
+++ b/src/HoneybadgerSourceMapPlugin.js
@@ -4,7 +4,7 @@ import VError from 'verror';
 import find from 'lodash.find';
 import reduce from 'lodash.reduce';
 import { handleError, validateOptions } from './helpers';
-import { ENDPOINT } from './constants';
+import { ENDPOINT, PLUGIN_NAME } from './constants';
 
 class HoneybadgerSourceMapPlugin {
   constructor({
@@ -42,7 +42,11 @@ class HoneybadgerSourceMapPlugin {
   }
 
   apply(compiler) {
-    compiler.plugin('after-emit', this.afterEmit.bind(this));
+    if (compiler.hooks) {
+      compiler.hooks.afterEmit.tapAsync(PLUGIN_NAME, this.afterEmit.bind(this));
+    } else {
+      compiler.plugin('after-emit', this.afterEmit.bind(this));
+    }
   }
 
   getAssets(compilation) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
+export const PLUGIN_NAME = 'HoneybadgerSourceMapPlugin'
 export const ENDPOINT = 'https://api.honeybadger.io/v1/source_maps ';
 
 export const REQUIRED_FIELDS = [

--- a/test/HoneybadgerSourceMapPlugin.test.js
+++ b/test/HoneybadgerSourceMapPlugin.test.js
@@ -5,7 +5,11 @@ import HoneybadgerSourceMapPlugin from '../src/HoneybadgerSourceMapPlugin';
 describe('HoneybadgerSourceMapPlugin', function() {
   beforeEach(function() {
     this.compiler = {
-      plugin: createSpy()
+      hooks: {
+        afterEmit: {
+          tapAsync: createSpy(),
+        },
+      },
     };
 
     this.options = {
@@ -41,28 +45,24 @@ describe('HoneybadgerSourceMapPlugin', function() {
   });
 
   describe('apply', function() {
-    it('should hook into "after-emit"', function() {
-      expect(this.compiler.plugin.calls.length).toBe(1);
-      expect(this.compiler.plugin.calls[0].arguments).toEqual([
-        'after-emit',
-        this.plugin.afterEmit.bind(this.plugin)
-      ]);
-    });
-
     it('should tap into "afterEmit" hook', function() {
-      this.compiler.hooks = {
-        afterEmit: {
-          tapAsync: createSpy(),
-        }
-      }
-
-      this.plugin.apply(this.compiler);
-
       const { afterEmit } = this.compiler.hooks
 
       expect(afterEmit.tapAsync.calls.length).toBe(1);
       expect(afterEmit.tapAsync.calls[0].arguments).toEqual([
         'HoneybadgerSourceMapPlugin',
+        this.plugin.afterEmit.bind(this.plugin)
+      ]);
+    });
+
+    it('should hook into "after-emit"', function() {
+      this.compiler.hooks = null
+      this.compiler.plugin = createSpy()
+      this.plugin.apply(this.compiler);
+
+      expect(this.compiler.plugin.calls.length).toBe(1);
+      expect(this.compiler.plugin.calls[0].arguments).toEqual([
+        'after-emit',
         this.plugin.afterEmit.bind(this.plugin)
       ]);
     });

--- a/test/HoneybadgerSourceMapPlugin.test.js
+++ b/test/HoneybadgerSourceMapPlugin.test.js
@@ -41,10 +41,28 @@ describe('HoneybadgerSourceMapPlugin', function() {
   });
 
   describe('apply', function() {
-    it('should hook into `after-emit"', function() {
+    it('should hook into "after-emit"', function() {
       expect(this.compiler.plugin.calls.length).toBe(1);
       expect(this.compiler.plugin.calls[0].arguments).toEqual([
         'after-emit',
+        this.plugin.afterEmit.bind(this.plugin)
+      ]);
+    });
+
+    it('should tap into "afterEmit" hook', function() {
+      this.compiler.hooks = {
+        afterEmit: {
+          tapAsync: createSpy(),
+        }
+      }
+
+      this.plugin.apply(this.compiler);
+
+      const { afterEmit } = this.compiler.hooks
+
+      expect(afterEmit.tapAsync.calls.length).toBe(1);
+      expect(afterEmit.tapAsync.calls[0].arguments).toEqual([
+        'HoneybadgerSourceMapPlugin',
         this.plugin.afterEmit.bind(this.plugin)
       ]);
     });


### PR DESCRIPTION
- Updates plugin to use Webpack 4's new `tap` as the plugin method is now deprecated and produces a warning.
- Adds accommodating test and refactoring to make v4 default in test setup.
- Adds PLUGIN_NAME constant.

I would appreciate if someone could test in their Webpack 4 setup before merging.