### PR TITLE
Adjust sample config in README to latest webpacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const HoneybadgerSourceMapPlugin = require('@honeybadger-io/webpack')
 // named GIT_COMMIT, HONEYBADGER_API_KEY, ASSETS_URL
 const revision = process.env.GIT_COMMIT || 'master'
 
-environment.plugins.set(
+environment.plugins.append(
   'HoneybadgerSourceMap',
   new HoneybadgerSourceMapPlugin({
     apiKey: process.env.HONEYBADGER_API_KEY,


### PR DESCRIPTION
## Status
**READY**

## Description
To adjust sample config to [webpacker](https://github.com/rails/webpacker) >= v.3.3.0.
The source: https://github.com/rails/webpacker/blob/master/CHANGELOG.md#330---2018-03-03.

This fixes the following error (when using webpacker >= v.3.3.0):

```
TypeError: environment.plugins.set is not a function
```