### PR TITLE
Fixes sourceFile path

### DIFF
--- a/src/HoneybadgerSourceMapPlugin.js
+++ b/src/HoneybadgerSourceMapPlugin.js
@@ -70,8 +70,6 @@ class HoneybadgerSourceMapPlugin {
   }
 
   uploadSourceMap(compilation, { sourceFile, sourceMap }, done) {
-    sourceFile = sourceFile.replace(/^\//, '')
-    
     const req = request.post(ENDPOINT, (err, res, body) => {
       if (!err && res.statusCode === 201) {
         if (!this.silent) {
@@ -95,7 +93,7 @@ class HoneybadgerSourceMapPlugin {
 
     const form = req.form();
     form.append('api_key', this.apiKey);
-    form.append('minified_url', `${this.assetsUrl}/${sourceFile}`);
+    form.append('minified_url', `${this.assetsUrl}/${sourceFile.replace(/^\//, '')}`);
     form.append('minified_file', compilation.assets[sourceFile].source(), {
       filename: sourceFile,
       contentType: 'application/javascript'


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Well, my last PR (#73) broke the local path reference internally from Webpack. This PR fixes it by just updating what is sent to Honeybadger and not messing with other internal Webpack references.

## Related PRs
n/a

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> npm test
```
