### PR TITLE
uploadSourceMaps: don't call done() twice on error

### DIFF
--- a/src/HoneybadgerSourceMapPlugin.js
+++ b/src/HoneybadgerSourceMapPlugin.js
@@ -83,12 +83,16 @@ class HoneybadgerSourceMapPlugin {
         return done(new VError(err, errMessage));
       }
 
+      let result;
+
       try {
         const { error } = JSON.parse(body);
-        return done(new Error(error ? `${errMessage}: ${error}` : errMessage));
+        result = new Error(error ? `${errMessage}: ${error}` : errMessage);
       } catch (parseErr) {
-        return done(new VError(parseErr, errMessage));
+        result = new VError(parseErr, errMessage);
       }
+
+      return done(result);
     });
 
     const form = req.form();


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description

When source map uploads fail, instead of printing the error, it causes an internal error:

**Before**
```
Error: Callback was already called.
    at /data/redacted/releases/20190416051404/node_modules/async/dist/async.js:966:32
    at Request._callback (/data/redacted/releases/20190416051404/node_modules/@honeybadger-io/webpack/dist/HoneybadgerSourceMapPlugin.js:146:18)
```

**After**
```
ERROR in HoneybadgerSourceMapPlugin: failed to upload 91-45f327f06650ca61fcaa.js.map to Honeybadger
 API: Internal Server Error
```

In these examples `done()` raises an error with message "Error: Hash: 161e1d517e3b69254443", the cause of which I have yet to determine.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Try to upload source maps when Honeybadger rejects them. I have yet to determine why the api is returning "Internal Server Error", but at least I can see a sensible error.