### PR TITLE
Batch uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ These plugin parameters correspond to the [Honeybadger Sourcemap API](https://do
 
   <dt><code>ignoreErrors</code> (optional &mdash; default: "null/false")</dt>
   <dd>If true, webpack compilation errors are treated as warnings.</dd>
+
+  <dt><code>uploadConcurrency</code> (optional &mdash; default: "Infinity")</dt>
+  <dd>The maximum number of upload requests that the plugin will make in parallel. Limiting the number of parallel requests may help prevent upload failures if you have many source map files.</dd>
 </dl>
 
 ### Vanilla webpack.config.js


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**WIP** (behavior ready, but no unit tests)

## Description
Recently we have been having issues with source map uploads failing. I suspect this may have to do with the fact that our project has a very large number of chunks (about 200) which each need to upload their own source map, and the current implementation of the plugin seems to start all upload requests simultaneously.

This PR adds an option to limit the number of parallel requests in the hopes that it will reduce the frequency of upload failures.

Does this seem like a reasonable approach/implementation? If so, I will add some basic tests for it.

## Related PRs
None

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Pass a numeric value for the new `uploadConcurrency` plugin option (if no value is passed, the behavior should be the same as the current version)
2. The plugin should only make up to `uploadConcurrency` upload requests at the same time