### PR TITLE
Remove an extra space in the honeybadger endpoint.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 export const PLUGIN_NAME = 'HoneybadgerSourceMapPlugin'
-export const ENDPOINT = 'https://api.honeybadger.io/v1/source_maps ';
+export const ENDPOINT = 'https://api.honeybadger.io/v1/source_maps';
 
 export const REQUIRED_FIELDS = [
   'apiKey',


### PR DESCRIPTION
Was browsing through and grokking the code and found the endpoint had an extra space, not a big deal, but also probably shouldnt be there either.