### PR TITLE
Fix/switch to console info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [fetch-retry](https://github.com/vercel/fetch-retry)
 - Add a retry option that defaults to 3, with a max number of retries
   of 10.
-- Add a warning if no assets will be uploaded
+- Add a warning if no assets will be uploaded. Uses console.info instead
+of process.stdout.write.
 - Add a configurable `endpoint` to the constructor, defaults to
   `https://api.honeybadger.io/v1/source_maps`
 

--- a/src/HoneybadgerSourceMapPlugin.js
+++ b/src/HoneybadgerSourceMapPlugin.js
@@ -152,17 +152,21 @@ class HoneybadgerSourceMapPlugin {
       // this is also an open issue on Rollbar sourcemap plugin
       // https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/39
       if (!this.silent) {
-        process.stdout.write('No assets found. Nothing will be uploaded.')
+        console.info(this.noAssetsFoundMessage)
       }
 
       return
     }
 
-    process.stdout.write('\n')
+    console.info('\n')
 
     return Promise.all(
       assets.map(asset => this.uploadSourceMap(compilation, asset))
     )
+  }
+
+  get noAssetsFoundMessage () {
+    return 'Honeybadger could not find any sourcemaps. Nothing will be uploaded.'
   }
 }
 

--- a/test/HoneybadgerSourceMapPlugin.test.js
+++ b/test/HoneybadgerSourceMapPlugin.test.js
@@ -279,9 +279,9 @@ describe(PLUGIN_NAME, function () {
 
     context('If no sourcemaps are found', function () {
       it('Should warn a user if silent is false', async function () {
-        sinon.stub(process.stdout, 'write')
         this.plugin.getAssets.restore()
         sinon.stub(this.plugin, 'getAssets').returns([])
+        const info = sinon.stub(console, 'info')
 
         nock(TEST_ENDPOINT)
           .filteringRequestBody(function (_body) { return '*' })
@@ -293,20 +293,16 @@ describe(PLUGIN_NAME, function () {
 
         await this.plugin.uploadSourceMaps(compilation)
 
-        expect(process.stdout.write.calledWith('No assets found. Nothing will be uploaded.')).to.eq(true)
-
-        // manually called because we overwrite stdout
-        sinon.restore()
+        expect(info.calledWith(this.plugin.noAssetsFoundMessage)).to.eq(true)
       })
 
       it('Should not warn a user if silent is true', async function () {
-        sinon.stub(process.stdout, 'write')
         this.plugin.getAssets.restore()
         sinon.stub(this.plugin, 'getAssets').returns([])
+        const info = sinon.stub(console, 'info')
 
         nock(TEST_ENDPOINT)
-          .filteringRequestBody(function (_body) { return '*' })
-          .post(SOURCEMAP_PATH, '*')
+          .post(SOURCEMAP_PATH)
           .reply(200, JSON.stringify({ status: 'OK' }))
 
         const { compilation } = this
@@ -314,10 +310,7 @@ describe(PLUGIN_NAME, function () {
 
         await this.plugin.uploadSourceMaps(compilation)
 
-        expect(process.stdout.write.notCalled).to.eq(true)
-
-        // manually called because we overwrite stdout
-        sinon.restore()
+        expect(info.notCalled).to.eq(true)
       })
     })
   })
@@ -437,8 +430,7 @@ describe(PLUGIN_NAME, function () {
       const endpoint = 'https://my-special-endpoint'
       const plugin = new HoneybadgerSourceMapPlugin({ ...this.options, endpoint: `${endpoint}${SOURCEMAP_PATH}` })
       nock(endpoint)
-        .filteringRequestBody(function (_body) { return '*' })
-        .post(SOURCEMAP_PATH, '*')
+        .post(SOURCEMAP_PATH)
         .reply(201, JSON.stringify({ status: 'OK' }))
 
       const { compilation, chunk } = this


### PR DESCRIPTION
## Status

READY/WIP/HOLD

## Description

When running the plugin through an external process like `next.js` the reporting for not finding any assets doesnt propagate to the users log because its currently using `process.stdout.write` instead of `console.info`. This PR fixes that.

## Related issues

fixes #291 