### PR TITLE
feat: upload files with workers

### DIFF
--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,0 +1,1 @@
+require: '@babel/register'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add worker support when uploading sourcemaps. Defaults to 5 files
+  being uploaded in parallel.
 
 ## [1.3.0] - 2021-04-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ These plugin parameters correspond to the [Honeybadger Sourcemap API](https://do
   Retrying helps fix issues like `ECONNRESET` and `SOCKETTIMEOUT`
   errors and retries on 429 and 500 errors as well.
   </dd>
+
+  <dt><code>workerCount</code> (optional &mdash; default: 5, min: 1)</dt>
+  <dd>Sourcemaps are uploaded in parallel by a configurable number of 
+  workers. Increase or decrease this value to configure how many sourcemaps
+  are being uploaded in parallel.</br>
+  Limited parallelism helps with connection issues in Docker environments.</dd>
 </dl>
 
 ### Vanilla webpack.config.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf dist",
     "prebuild": "npm run -s clean",
     "prepublishOnly": "npm run clean && npm run build && npm run test",
-    "test": "mocha --require @babel/register",
+    "test": "mocha",
     "test:watch": "npm test -- -w",
     "preversion": "npm test",
     "version": "scripts/update-versions.sh",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 export const PLUGIN_NAME = 'HoneybadgerSourceMapPlugin'
 export const ENDPOINT = 'https://api.honeybadger.io/v1/source_maps'
 export const MAX_RETRIES = 10
+export const MIN_WORKER_COUNT = 1
 
 export const REQUIRED_FIELDS = [
   'apiKey',

--- a/src/resolvePromiseWithWorkers.js
+++ b/src/resolvePromiseWithWorkers.js
@@ -1,0 +1,36 @@
+function * generator (
+  promiseFactories
+) {
+  for (let i = 0; i < promiseFactories.length; ++i) {
+    yield [promiseFactories[i](), i]
+  }
+}
+
+async function worker (generator, results) {
+  for (const [promise, index] of generator) {
+    results[index] = await promise
+  }
+}
+
+export async function resolvePromiseWithWorkers (
+  promiseFactories,
+  workerCount
+) {
+  // The generator and the results are shared between workers, ensuring each promise is only resolved once
+  const sharedGenerator = generator(promiseFactories)
+  const results = []
+
+  // There's no need to create more workers than promises to resolve
+  const actualWorkerCount = Math.min(
+    workerCount,
+    promiseFactories.length
+  )
+
+  const workers = Array.from(new Array(actualWorkerCount)).map(() =>
+    worker(sharedGenerator, results)
+  )
+
+  await Promise.all(workers)
+
+  return results
+}

--- a/test/HoneybadgerSourceMapPlugin.test.js
+++ b/test/HoneybadgerSourceMapPlugin.test.js
@@ -6,7 +6,7 @@ import nock from 'nock'
 
 import { promises as fs } from 'fs'
 import HoneybadgerSourceMapPlugin from '../src/HoneybadgerSourceMapPlugin'
-import { ENDPOINT, MAX_RETRIES, PLUGIN_NAME } from '../src/constants'
+import { ENDPOINT, MAX_RETRIES, MIN_WORKER_COUNT, PLUGIN_NAME } from '../src/constants'
 
 const expect = chai.expect
 
@@ -56,6 +56,15 @@ describe(PLUGIN_NAME, function () {
 
     it('should default retries to 3', function () {
       expect(this.plugin).to.include({ retries: 3 })
+    })
+
+    it('should default workerCount to 5', function () {
+      expect(this.plugin).to.include({ workerCount: 5 })
+    })
+
+    it('should default a minimum worker count', function () {
+      const plugin = new HoneybadgerSourceMapPlugin({ workerCount: -1 })
+      expect(plugin).to.include({ workerCount: MIN_WORKER_COUNT })
     })
 
     it('should default endpoint to https://api.honeybadger.io/v1/source_maps', function () {

--- a/test/resolvePromiseWithWorkers.test.js
+++ b/test/resolvePromiseWithWorkers.test.js
@@ -1,0 +1,103 @@
+/* eslint-env mocha */
+
+import chai from 'chai'
+import sinon from 'sinon'
+
+import { resolvePromiseWithWorkers } from '../src/resolvePromiseWithWorkers'
+
+const expect = chai.expect
+
+function asyncPromiseGenerator (
+  name,
+  timeout,
+  traceCallback
+) {
+  return new Promise((resolve) => {
+    if (typeof traceCallback === 'function') {
+      traceCallback(`start ${name}`)
+    }
+
+    setTimeout(() => {
+      if (typeof traceCallback === 'function') {
+        traceCallback(`resolve ${name}`)
+      }
+      resolve(name)
+    }, timeout)
+  })
+}
+
+function assertCallSequence (
+  spy,
+  sequence
+) {
+  for (let i = 0; i < sequence.length; ++i) {
+    sinon.assert.calledWith(spy.getCall(i), sequence[i])
+  }
+}
+
+const promises = [
+  () => asyncPromiseGenerator('First', 1),
+  () => asyncPromiseGenerator('Second', 10),
+  () => asyncPromiseGenerator('Third', 3)
+]
+
+describe('resolvePromiseWithWorkers', function () {
+  it('should resolve all promises', async function () {
+    expect(await resolvePromiseWithWorkers(promises, 5))
+      .to.deep.eq(['First', 'Second', 'Third'])
+  })
+
+  it('should resolve all promises if the number of workers is lower than the number of promises', async function () {
+    expect(await resolvePromiseWithWorkers(promises, 1))
+      .to.deep.eq(['First', 'Second', 'Third'])
+  })
+
+  it('should resolve the promises sequentially if the number of worker is 1', async function () {
+    const spy = sinon.spy()
+    const promisesWithCallback = [
+      () => asyncPromiseGenerator('First', 1, spy),
+      () => asyncPromiseGenerator('Second', 3, spy),
+      () => asyncPromiseGenerator('Third', 5, spy)
+    ]
+
+    await resolvePromiseWithWorkers(promisesWithCallback, 1)
+
+    const sequence = [
+      'start First',
+      'resolve First',
+      'start Second',
+      'resolve Second',
+      'start Third',
+      'resolve Third'
+    ]
+    assertCallSequence(spy, sequence)
+  })
+
+  it('should resolve the promises by workers', async function () {
+    const spy = sinon.spy()
+    const promisesWithCallback = [
+      () => asyncPromiseGenerator('First', 1, spy),
+      () =>
+        asyncPromiseGenerator(
+          'Second',
+          10 /* A very long promise that should keep a worker busy */,
+          spy
+        ),
+      () => asyncPromiseGenerator('Third', 1, spy),
+      () => asyncPromiseGenerator('Forth', 1, spy)
+    ]
+
+    await resolvePromiseWithWorkers(promisesWithCallback, 2)
+    const sequence = [
+      'start First',
+      'start Second',
+      'resolve First',
+      'start Third',
+      'resolve Third',
+      'start Forth',
+      'resolve Forth',
+      'resolve Second'
+    ]
+    assertCallSequence(spy, sequence)
+  })
+})


### PR DESCRIPTION
## Status
**READY**

## Description

The goal if this PR is to add a basic worker support to upload sourcemaps.

This worker support is needed on very large projects so all sourcemaps are not being uploaded in parallel (see https://github.com/honeybadger-io/honeybadger-webpack/issues/299) This should help with Dockerized environments, such as CIs (Jenkins, GitHub Actions, etc...)

The implementation revolves around two core tenets:

1. The promise created by `uploadSourceMap` is now wrapped in a closure, giving us more control on when the promise is created and thus the sourcemap file is uploaded
2. The promises are resolved by a generator; this generator can be consumed by a configurable number of workers

This implementation is based on this sandbox: https://github.com/Pierre-Do/promise-scheduler. The generator approach is shamelessly inspired from a publication by [Alex Ewerlöf](https://codeburst.io/async-map-with-limited-parallelism-in-node-js-2b91bd47af70)

This feature has been QA-ed on production environments using this fork: https://github.com/qoqa/honeybadger-webpack/commit/0078ee289937ea3aa37a437216cf072749a72e80. Cheers to my team at [QoQa](https://github.com/qoqa) for the support :100: 

Fix for https://github.com/honeybadger-io/honeybadger-webpack/issues/299

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can run all tests with the usual test command `npm test`.
