### PR TITLE
#325 Don't upload source maps to Honeybadger if webpack dev server is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Don't upload source maps if app is running with webpack-dev-server (#325)
+
 ## [1.5.0] - 2021-06-21
 ### Added
 - Support for sending deployment notifications

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Fixed
 - Don't upload source maps if app is running with webpack-dev-server (#325)
 
 ## [1.5.0] - 2021-06-21

--- a/src/HoneybadgerSourceMapPlugin.js
+++ b/src/HoneybadgerSourceMapPlugin.js
@@ -37,18 +37,25 @@ class HoneybadgerSourceMapPlugin {
     this.revision = revision
     this.silent = silent
     this.ignoreErrors = ignoreErrors
-    this.emittedAssets = new Map()
     this.workerCount = Math.max(workerCount, MIN_WORKER_COUNT)
-    /** @type DeployObject */
+    /** @type DeployObject|boolean */
     this.deploy = deploy
     this.retries = retries
 
     if (this.retries > MAX_RETRIES) {
-      this.retries = 10
+      this.retries = MAX_RETRIES
     }
   }
 
   async afterEmit (compilation) {
+    if (this.isDevServerRunning()) {
+      if (!this.silent) {
+        console.info('\nHoneybadgerSourceMapPlugin will not upload source maps because webpack-dev-server is running.')
+      }
+
+      return
+    }
+
     const errors = validateOptions(this)
 
     if (errors) {
@@ -66,6 +73,10 @@ class HoneybadgerSourceMapPlugin {
         compilation.warnings.push(...handleError(err))
       }
     }
+  }
+
+  isDevServerRunning () {
+    return process.env.WEBPACK_DEV_SERVER === 'true'
   }
 
   apply (compiler) {


### PR DESCRIPTION
## Status
**READY**

## Description
A few sentences describing the overall goals of the pull request's commits.

## Todos
- [x] Exit if app is running with `webpack-dev-server`
- [ ] Documentation - is this necessary?
- [x] Changelog Entry (unreleased)
